### PR TITLE
Add code coverage

### DIFF
--- a/test-support/helpers/ember-cognito.js
+++ b/test-support/helpers/ember-cognito.js
@@ -14,3 +14,7 @@ export function unmockCognitoUser(app) {
   cognito.set('user', undefined);
   return wait();
 }
+
+export function getAuthenticator(app) {
+  return app.__container__.lookup('authenticator:cognito');
+}

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,0 +1,35 @@
+import { currentSession } from '../../tests/helpers/ember-simple-auth';
+import Ember from 'ember';
+import { mockCognitoUser, getAuthenticator } from '../../tests/helpers/ember-cognito';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import test from 'ember-sinon-qunit/test-support/test';
+
+const { RSVP } = Ember;
+
+//
+// This is an example of testing authentication by stubbing the authenticator.
+// Because you may want to test more functionality within an acceptance test
+// (for instance, loading the current user and navigation on success),
+// you can't stub session.authenticate directly.
+//
+
+moduleForAcceptance('Acceptance | login');
+
+test('login', function(assert) {
+  let authenticator = getAuthenticator(this.application);
+  this.stub(authenticator, 'authenticate').callsFake(({ username }) => {
+    mockCognitoUser(this.application, { username });
+    return RSVP.resolve();
+  });
+
+  visit('/login');
+  fillIn('#username', 'testuser');
+  fillIn('#password', 'password');
+  click('[type=submit]');
+
+  andThen(() => {
+    let session = currentSession(this.application);
+    assert.equal(session.get('isAuthenticated'), true);
+    assert.equal(currentURL(), '/');
+  });
+});

--- a/tests/unit/controllers/login-test.js
+++ b/tests/unit/controllers/login-test.js
@@ -1,0 +1,104 @@
+import Ember from 'ember';
+import { moduleFor } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+import wait from 'ember-test-helpers/wait';
+
+const { RSVP } = Ember;
+
+//
+// This is an example of writing a unit test that uses sinon
+// to stub the Cognito authenticator.
+//
+// If you wanted to instead write an acceptance test, you could
+// get the current session from the app using ember-simple-auth's
+// currentSession() helper and use sinon to mock the service that way.
+//
+// NOTE: these tests use sinon.stub.callsFake() rather than sinon.stub.resolves/rejects
+// because PhantomJS doesn't support native promises. If you polyfill Promise
+// or don't care about PhantomJS, you can switch to using stub.resolves/rejects.
+//
+
+moduleFor('controller:login', 'Unit | Controller | login', {
+  needs: ['service:session']
+});
+
+function resolves(value) {
+  return () => RSVP.resolve(value);
+}
+
+function rejects(value) {
+  return () => RSVP.reject(value);
+}
+
+test('login success', function(assert) {
+  let controller = this.subject();
+  let stub = this.stub(controller.get('session'), 'authenticate').callsFake(resolves({}));
+  controller.setProperties({ username: 'testuser', password: 'pw' });
+  controller.send('login', new Event('click'));
+  assert.deepEqual(stub.args, [[
+    'authenticator:cognito',
+    { username: 'testuser', password: 'pw' }
+  ]]);
+  return wait();
+});
+
+test('login fail', function(assert) {
+  let controller = this.subject();
+  let stub = this.stub(controller.get('session'), 'authenticate').callsFake(rejects(new Error('invalid password')));
+  controller.setProperties({ username: 'testuser', password: 'pw' });
+  controller.send('login', new Event('click'));
+
+  assert.deepEqual(stub.args, [[
+    'authenticator:cognito',
+    { username: 'testuser', password: 'pw' }
+  ]]);
+  return wait().then(() => {
+    assert.equal(controller.get('errorMessage'), 'invalid password');
+  });
+});
+
+test('login newPasswordRequired', function(assert) {
+  let controller = this.subject();
+  let err = { state: { name: 'newPasswordRequired' } };
+  let stub = this.stub(controller.get('session'), 'authenticate').callsFake(rejects(err));
+  controller.setProperties({ username: 'testuser', password: 'pw' });
+  controller.send('login', new Event('click'));
+
+  assert.deepEqual(stub.args, [[
+    'authenticator:cognito',
+    { username: 'testuser', password: 'pw' }
+  ]]);
+  return wait().then(() => {
+    assert.equal(controller.get('errorMessage'), '');
+    assert.equal(controller.get('state'), err.state);
+  });
+});
+
+test('newPasswordRequired success', function(assert) {
+  let controller = this.subject();
+  let stub = this.stub(controller.get('session'), 'authenticate').callsFake(resolves({}));
+  let state = { name: 'newPasswordRequired', arg: 'foo' };
+  controller.setProperties({ newPassword: 'pw', state });
+  controller.send('newPassword', new Event('click'));
+  assert.deepEqual(stub.args, [[
+    'authenticator:cognito',
+    { password: 'pw', state }
+  ]]);
+  return wait();
+});
+
+test('newPasswordRequired fail', function(assert) {
+  let controller = this.subject();
+  let stub = this.stub(controller.get('session'), 'authenticate').callsFake(rejects(new Error('something went wrong')));
+  let state = { name: 'newPasswordRequired', arg: 'foo' };
+  controller.setProperties({ newPassword: 'pw', state });
+  controller.send('newPassword', new Event('click'));
+  assert.deepEqual(stub.args, [[
+    'authenticator:cognito',
+    { password: 'pw', state }
+  ]]);
+  return wait().then(() => {
+    assert.equal(controller.get('errorMessage'), 'something went wrong');
+    assert.equal(controller.get('state'), state);
+  });
+});


### PR DESCRIPTION
1. Codeclimate looks for codecoverage of our *dummy* code.
2. This actually provides examples of how to stub the authenticator to test login flows, and eats our own test dog food.