### PR TITLE
Prepare for Fastboot 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ module.exports = {
       'amazon-cognito-identity-js': function() {
         return {
           vendor: {
-            enabled: process.env.EMBER_CLI_FASTBOOT !== 'true',
             srcDir: 'dist',
             include: [
               'aws-cognito-sdk.js',


### PR DESCRIPTION
Since in Fastboot 1.0 there won’t be a Fastboot build, and EMBER_CLI_FASTBOOT will no longer exist.

https://github.com/ember-fastboot/ember-cli-fastboot/issues/387