### PR TITLE
Authenticate function call fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ export default Ember.Controller.extend({
   actions: {
     authenticate() {
       let { username, password } = this.getProperties('username', 'password');
-      this.get('session').authenticate('authenticator:cognito', username, password).then((cognitoUserSession) => {
+      let credentials = { 
+        username: username,
+        password: password
+      };
+      this.get('session').authenticate('authenticator:cognito', credentials).then((cognitoUserSession) => {
         // Successfully authenticated!  
       }).catch((error) => {
         this.set('errorMessage', error.message || error);


### PR DESCRIPTION
Looks like the authenticate example has a small error in the README. It took me a little while to figure that one out so I thought I'd share.