### PR TITLE
Revert "Update to new modules"

### DIFF
--- a/addon/authenticators/cognito.js
+++ b/addon/authenticators/cognito.js
@@ -1,16 +1,18 @@
-import { readOnly } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
-import { merge } from '@ember/polyfills';
-import RSVP from 'rsvp';
-import { getProperties, set } from '@ember/object';
 import { AuthenticationDetails } from 'amazon-cognito-identity-js';
-import {
-  CognitoUser as AWSCognitoUser,
-  CognitoUserPool
-} from 'amazon-cognito-identity-js';
+import { CognitoUser as AWSCognitoUser, CognitoUserPool } from 'amazon-cognito-identity-js';
 import Base from 'ember-simple-auth/authenticators/base';
 import CognitoStorage from '../utils/cognito-storage';
 import CognitoUser from '../utils/cognito-user';
+import Ember from 'ember';
+
+const {
+  computed: { readOnly },
+  inject: { service },
+  merge,
+  RSVP,
+  set,
+  getProperties
+} = Ember;
 
 export default Base.extend({
   cognito: service(),

--- a/addon/services/cognito.js
+++ b/addon/services/cognito.js
@@ -1,4 +1,6 @@
-import Service from '@ember/service';
+import Ember from 'ember';
+
+const { Service } = Ember;
 
 /**
  * @public

--- a/addon/utils/cognito-user.js
+++ b/addon/utils/cognito-user.js
@@ -1,5 +1,11 @@
-import RSVP from 'rsvp';
-import EmberObject, { get, computed } from '@ember/object';
+import Ember from 'ember';
+
+const {
+  computed,
+  Object: EmberObject,
+  RSVP,
+  get
+} = Ember;
 
 //
 // Wraps an AWS CognitoUser and provides promisified versions of many functions.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-release": "^1.0.0-beta.2",
-    "ember-cli-shims": "^1.2.0-beta.2",
+    "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-update": "^0.6.4",

--- a/test-support/helpers/ember-cognito.js
+++ b/test-support/helpers/ember-cognito.js
@@ -1,6 +1,8 @@
 /* global wait */
 import { MockUser } from '../utils/ember-cognito';
-import { set } from '@ember/object';
+import Ember from 'ember';
+
+const { set } = Ember;
 
 export function mockCognitoUser(app, userAttributes) {
   const { __container__: container } = app;

--- a/test-support/utils/ember-cognito.js
+++ b/test-support/utils/ember-cognito.js
@@ -3,14 +3,15 @@ import { CognitoUserAttribute } from 'amazon-cognito-identity-js';
 
 const {
   Object: EmberObject,
-  RSVP
+  RSVP,
+  get
 } = Ember;
 
 const MockUser = EmberObject.extend({
   userAttributes: [],
 
   getUserAttributes() {
-    return RSVP.resolve(this.get('userAttributes').map(({ name, value }) => {
+    return RSVP.resolve(get(this, 'userAttributes').map(({ name, value }) => {
       return new CognitoUserAttribute({ Name: name, Value: value });
     }));
   }

--- a/test-support/utils/ember-cognito.js
+++ b/test-support/utils/ember-cognito.js
@@ -1,12 +1,16 @@
-import EmberObject, { get } from '@ember/object';
-import RSVP from 'rsvp';
+import Ember from 'ember';
 import { CognitoUserAttribute } from 'amazon-cognito-identity-js';
+
+const {
+  Object: EmberObject,
+  RSVP
+} = Ember;
 
 const MockUser = EmberObject.extend({
   userAttributes: [],
 
   getUserAttributes() {
-    return RSVP.resolve(get(this, 'userAttributes').map(({ name, value }) => {
+    return RSVP.resolve(this.get('userAttributes').map(({ name, value }) => {
       return new CognitoUserAttribute({ Name: name, Value: value });
     }));
   }

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,9 +1,10 @@
-import { get } from '@ember/object';
-import RSVP from 'rsvp';
 import { currentSession } from '../../tests/helpers/ember-simple-auth';
+import Ember from 'ember';
 import { mockCognitoUser, getAuthenticator } from '../../tests/helpers/ember-cognito';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import test from 'ember-sinon-qunit/test-support/test';
+
+const { get, RSVP } = Ember;
 
 //
 // This is an example of testing authentication by stubbing the authenticator.

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,7 +1,9 @@
-import Application from '@ember/application';
+import Ember from 'ember';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
+
+const { Application } = Ember;
 
 const App = Application.extend({
   modulePrefix: config.modulePrefix,

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,5 +1,9 @@
-import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import Ember from 'ember';
+
+const {
+  Controller,
+  inject: { service }
+} = Ember;
 
 export default Controller.extend({
   currentUser: service(),

--- a/tests/dummy/app/controllers/login.js
+++ b/tests/dummy/app/controllers/login.js
@@ -1,7 +1,13 @@
-import { equal } from '@ember/object/computed';
-import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
-import { set, getProperties, get } from '@ember/object';
+import Ember from 'ember';
+
+const {
+  computed: { equal },
+  Controller,
+  inject: { service },
+  get,
+  getProperties,
+  set
+} = Ember;
 
 export default Controller.extend({
   session: service(),

--- a/tests/dummy/app/controllers/profile.js
+++ b/tests/dummy/app/controllers/profile.js
@@ -1,5 +1,9 @@
-import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import Ember from 'ember';
+
+const {
+  Controller,
+  inject: { service }
+} = Ember;
 
 export default Controller.extend({
   currentUser: service(),

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,5 +1,7 @@
-import EmberRouter from '@ember/routing/router';
+import Ember from 'ember';
 import config from './config/environment';
+
+const { Router: EmberRouter } = Ember;
 
 const Router = EmberRouter.extend({
   location: config.locationType,

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,6 +1,10 @@
-import { inject as service } from '@ember/service';
-import Route from '@ember/routing/route';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
+import Ember from 'ember';
+
+const {
+  inject: { service },
+  Route
+} = Ember;
 
 export default Route.extend(ApplicationRouteMixin, {
   currentUser: service(),

--- a/tests/dummy/app/routes/profile.js
+++ b/tests/dummy/app/routes/profile.js
@@ -1,4 +1,6 @@
-import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import Ember from 'ember';
+
+const { Route } = Ember;
 
 export default Route.extend(AuthenticatedRouteMixin);

--- a/tests/dummy/app/services/current-user.js
+++ b/tests/dummy/app/services/current-user.js
@@ -1,6 +1,11 @@
-import { readOnly } from '@ember/object/computed';
-import RSVP from 'rsvp';
-import Service, { inject as service } from '@ember/service';
+import Ember from 'ember';
+
+const {
+  computed: { readOnly },
+  inject: { service },
+  RSVP,
+  Service
+} = Ember;
 
 export default Service.extend({
   session: service(),

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,4 +1,6 @@
-import { run } from '@ember/runloop';
+import Ember from 'ember';
+
+const { run } = Ember;
 
 export default function destroyApp(application) {
   run(application, 'destroy');

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,7 +1,9 @@
-import { resolve } from 'rsvp';
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,7 +1,8 @@
-import { merge } from '@ember/polyfills';
-import { run } from '@ember/runloop';
+import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
+
+const { merge, run } = Ember;
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);

--- a/tests/unit/authenticators/cognito-test.js
+++ b/tests/unit/authenticators/cognito-test.js
@@ -1,4 +1,3 @@
-import { set, get } from '@ember/object';
 import {
   CognitoAccessToken,
   CognitoIdToken,
@@ -7,6 +6,12 @@ import {
 } from 'amazon-cognito-identity-js';
 import { moduleFor } from 'ember-qunit';
 import test from 'ember-sinon-qunit/test-support/test';
+import Ember from 'ember';
+
+const {
+  get,
+  set
+} = Ember;
 
 moduleFor('authenticator:cognito', 'Unit | Authenticator | cognito', {
   needs: ['service:cognito'],

--- a/tests/unit/controllers/login-test.js
+++ b/tests/unit/controllers/login-test.js
@@ -1,8 +1,13 @@
-import RSVP from 'rsvp';
-import { setProperties, get } from '@ember/object';
+import Ember from 'ember';
 import { moduleFor } from 'ember-qunit';
 import test from 'ember-sinon-qunit/test-support/test';
 import wait from 'ember-test-helpers/wait';
+
+const {
+  RSVP,
+  get,
+  setProperties
+} = Ember;
 
 //
 // This is an example of writing a unit test that uses sinon

--- a/tests/unit/services/cognito-test.js
+++ b/tests/unit/services/cognito-test.js
@@ -1,5 +1,7 @@
-import { get } from '@ember/object';
 import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+const { get } = Ember;
 
 moduleFor('service:cognito', 'Unit | Service | cognito', {
 });

--- a/tests/unit/utils/cognito-user-test.js
+++ b/tests/unit/utils/cognito-user-test.js
@@ -1,4 +1,3 @@
-import { get } from '@ember/object';
 import {
   CognitoAccessToken,
   CognitoIdToken,
@@ -11,6 +10,9 @@ import CognitoStorage from 'dummy/utils/cognito-storage';
 import CognitoUser from 'dummy/utils/cognito-user';
 import { module } from 'qunit';
 import test from 'ember-sinon-qunit/test-support/test';
+import Ember from 'ember';
+
+const { get } = Ember;
 
 module('Unit | Utility | cognito user');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2263,7 +2263,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-be
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
-ember-cli-babel@^6.1.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:
@@ -2465,12 +2465,12 @@ ember-cli-release@^1.0.0-beta.2:
     semver "^4.3.1"
     silent-error "^1.0.0"
 
-ember-cli-shims@^1.2.0-beta.2:
-  version "1.2.0-beta.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-shims/-/ember-cli-shims-1.2.0-beta.2.tgz#8be59edfca63574b8c9b5d469ec14b5cf3219470"
+ember-cli-shims@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-shims/-/ember-cli-shims-1.1.0.tgz#0e3b8a048be865b4f81cc81d397ff1eeb13f75b6"
   dependencies:
-    ember-cli-babel "^6.1.0"
-    ember-cli-version-checker "^2.0.0"
+    ember-cli-babel "^6.0.0-beta.7"
+    ember-cli-version-checker "^1.2.0"
     silent-error "^1.0.1"
 
 ember-cli-sri@^2.1.0:


### PR DESCRIPTION
This reverts the conversion to new modules.

I believe I can have this as long as the `test-support` directory only contains re-exports, but more investigation is needed to make that work.