### PR TITLE
Getting groups, and groups mocking

### DIFF
--- a/addon-test-support/utils/ember-cognito.js
+++ b/addon-test-support/utils/ember-cognito.js
@@ -1,9 +1,17 @@
 import { CognitoUserAttribute } from 'amazon-cognito-identity-js';
-import EmberObject, { get } from '@ember/object';
+import EmberObject, { get, set } from '@ember/object';
 import RSVP from 'rsvp';
 
 const MockUser = EmberObject.extend({
   userAttributes: [],
+
+  getGroups() {
+    return RSVP.resolve(get(this, 'groups'));
+  },
+
+  getSession() {
+    return RSVP.resolve(get(this, 'session'));
+  },
 
   getUserAttributes() {
     return RSVP.resolve(get(this, 'userAttributes').map(({ name, value }) => {

--- a/addon/utils/cognito-user.js
+++ b/addon/utils/cognito-user.js
@@ -29,6 +29,14 @@ export default EmberObject.extend({
     return this._callback('getUserAttributes');
   },
 
+  getGroups() {
+    return this.getSession().then((session) => {
+      let payload = session.getIdToken().getJwtToken().split('.')[1];
+      let obj = JSON.parse(atob(payload));
+      return obj['cognito:groups'] || [];
+    });
+  },
+
   signOut() {
     return get(this, 'user').signOut();
   },


### PR DESCRIPTION
This adds a helper function on the user to get the list of the users groups from the ID token. It also adds a simpler way of mocking groups or sessions from the `MockUser`.