### PR TITLE
Allow ember-beta to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add phantomjs-prebuilt
   - yarn global add greenkeeper-lockfile@1
 
 install:


### PR DESCRIPTION
It's apparently broken (along with ember-canary), probably because the latest betas aren't published to bower.