### PR TITLE
[Fixes #58] Convert tests to use async/await

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,13 +46,25 @@ module.exports = {
         // add your custom rules and overrides for node files here
       })
     },
-
+    {
+      files: [
+        'addon/**/*.js',
+        'app/**/*.js'
+      ],
+      plugins: [
+        'disable-features',
+      ],
+      rules: {
+        'disable-features/disable-async-await': 'error',
+        'disable-features/disable-generator-functions': 'error',
+      }
+    },
     // test files
     {
       files: ['tests/**/*.js'],
       excludedFiles: ['tests/dummy/**/*.js'],
       env: {
-        embertest: true
+        // embertest: true
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator-for-testing": "^1.0.0",
     "ember-native-dom-helpers": "^0.6.0",
     "ember-resolver": "^4.0.0",
     "ember-simple-auth": "^1.4.0",
@@ -50,6 +51,7 @@
     "ember-source": "~2.18.0",
     "ember-source-channel-url": "^1.0.1",
     "ember-welcome-page": "^3.0.0",
+    "eslint-plugin-disable-features": "^0.1.3",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,9 +1,10 @@
 import { get } from '@ember/object';
-import RSVP from 'rsvp';
+import { resolve } from 'rsvp';
 import { currentSession } from '../../tests/helpers/ember-simple-auth';
 import { mockCognitoUser, getAuthenticator } from '../../tests/helpers/ember-cognito';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import test from 'ember-sinon-qunit/test-support/test';
+import { visit, fillIn, click, currentURL } from 'ember-native-dom-helpers';
 
 //
 // This is an example of testing authentication by stubbing the authenticator.
@@ -14,21 +15,19 @@ import test from 'ember-sinon-qunit/test-support/test';
 
 moduleForAcceptance('Acceptance | login');
 
-test('login', function(assert) {
+test('login', async function(assert) {
   let authenticator = getAuthenticator(this.application);
   this.stub(authenticator, 'authenticate').callsFake(({ username }) => {
     mockCognitoUser(this.application, { username });
-    return RSVP.resolve();
+    return resolve();
   });
 
-  visit('/login');
-  fillIn('#username', 'testuser');
-  fillIn('#password', 'password');
-  click('[type=submit]');
+  await visit('/login');
+  await fillIn('#username', 'testuser');
+  await fillIn('#password', 'password');
+  await click('[type=submit]');
 
-  andThen(() => {
-    let session = currentSession(this.application);
-    assert.equal(get(session, 'isAuthenticated'), true);
-    assert.equal(currentURL(), '/');
-  });
+  let session = currentSession(this.application);
+  assert.equal(get(session, 'isAuthenticated'), true);
+  assert.equal(currentURL(), '/');
 });

--- a/tests/acceptance/nav-bar-test.js
+++ b/tests/acceptance/nav-bar-test.js
@@ -2,6 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import { authenticateSession } from '../../tests/helpers/ember-simple-auth';
 import { mockCognitoUser } from '../../tests/helpers/ember-cognito';
+import { visit, currentURL, find } from 'ember-native-dom-helpers';
 
 //
 // This is an example of how one could use the Cognito authenticator and service in an acceptance test.
@@ -9,27 +10,23 @@ import { mockCognitoUser } from '../../tests/helpers/ember-cognito';
 
 moduleForAcceptance('Acceptance | nav bar');
 
-test('logout', function(assert) {
-  visit('/');
+test('logout', async function(assert) {
+  await visit('/');
 
-  andThen(function() {
-    assert.equal(currentURL(), '/');
-    assert.equal(find('.login-link').length, 1);
-    assert.equal(find('.profile-link').length, 0);
-  });
+  assert.equal(currentURL(), '/');
+  assert.ok(find('.login-link'));
+  assert.notOk(find('.profile-link'));
 });
 
-test('login', function(assert) {
+test('login', async function(assert) {
   authenticateSession(this.application);
   mockCognitoUser(this.application, {
     username: 'testuser'
   });
-  visit('/');
+  await visit('/');
 
-  andThen(function() {
-    assert.equal(currentURL(), '/');
-    assert.equal(find('.login-link').length, 0);
-    assert.equal(find('.profile-link').length, 1);
-    assert.equal(find('.profile-link').text().trim(), 'testuser');
-  });
+  assert.equal(currentURL(), '/');
+  assert.notOk(find('.login-link'));
+  assert.ok(find('.profile-link'));
+  assert.equal(find('.profile-link').textContent.trim(), 'testuser');
 });

--- a/tests/acceptance/profile-test.js
+++ b/tests/acceptance/profile-test.js
@@ -2,22 +2,20 @@ import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import { authenticateSession } from '../../tests/helpers/ember-simple-auth';
 import { mockCognitoUser } from '../../tests/helpers/ember-cognito';
-import { findAll } from 'ember-native-dom-helpers';
+import { visit, currentURL, findAll } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | profile');
 
-test('visiting /profile unauthenticated', function(assert) {
-  visit('/profile');
+test('visiting /profile unauthenticated', async function(assert) {
+  await visit('/profile');
 
-  andThen(function() {
-    assert.equal(currentURL(), '/login');
-  });
+  assert.equal(currentURL(), '/login');
 });
 
 //
 // This is an example of how to mock user attributes in an acceptance test.
 //
-test('visiting /profile', function(assert) {
+test('visiting /profile', async function(assert) {
   authenticateSession(this.application);
   mockCognitoUser(this.application, {
     username: 'testuser',
@@ -28,20 +26,18 @@ test('visiting /profile', function(assert) {
     ]
   });
 
-  visit('/profile');
+  await visit('/profile');
 
-  andThen(function() {
-    assert.equal(currentURL(), '/profile');
-    // Map each element to get the text from it
-    let text = findAll('tbody td').map(function(elem) {
-      return elem.textContent.trim();
-    });
-
-    assert.deepEqual(text, [
-      'sub', 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh',
-      'username', 'testuser',
-      'email', 'testuser@gmail.com',
-      'email_verified', 'false'
-    ]);
+  assert.equal(currentURL(), '/profile');
+  // Map each element to get the text from it
+  let text = findAll('tbody td').map(function(elem) {
+    return elem.textContent.trim();
   });
+
+  assert.deepEqual(text, [
+    'sub', 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh',
+    'username', 'testuser',
+    'email', 'testuser@gmail.com',
+    'email_verified', 'false'
+  ]);
 });

--- a/tests/dummy/app/services/current-user.js
+++ b/tests/dummy/app/services/current-user.js
@@ -1,5 +1,5 @@
 import { readOnly } from '@ember/object/computed';
-import RSVP from 'rsvp';
+import { resolve } from 'rsvp';
 import Service, { inject as service } from '@ember/service';
 
 export default Service.extend({
@@ -16,7 +16,7 @@ export default Service.extend({
         });
       });
     } else {
-      return RSVP.resolve();
+      return resolve();
     }
   }
 });

--- a/tests/unit/services/cognito-test.js
+++ b/tests/unit/services/cognito-test.js
@@ -26,7 +26,7 @@ test('config is set correctly', function(assert) {
   assert.equal(get(service, 'clientId'), 'TEST');
 });
 
-sinonTest('signup works', function(assert) {
+sinonTest('signup works', async function(assert) {
   let service = this.subject();
   this.stubPoolMethod(service, 'signUp', (username, password, attributeList, validationData, callback) => {
     // Return data is:
@@ -40,15 +40,14 @@ sinonTest('signup works', function(assert) {
     });
   });
 
-  return service.signUp('testuser', 'password', [], null).then((result) => {
-    // The user should be upgraded to one of our users
-    assert.ok(result.user instanceof CognitoUser);
-    assert.equal(result.userConfirmed, true);
-    assert.equal(result.userSub, 'xxxx');
-  });
+  let result = await service.signUp('testuser', 'password', [], null);
+  // The user should be upgraded to one of our users
+  assert.ok(result.user instanceof CognitoUser);
+  assert.equal(result.userConfirmed, true);
+  assert.equal(result.userSub, 'xxxx');
 });
 
-sinonTest('signup error', function(assert) {
+sinonTest('signup error', async function(assert) {
   assert.expect(1);
 
   let service = this.subject();
@@ -60,9 +59,10 @@ sinonTest('signup error', function(assert) {
     callback('error', null);
   });
 
-  return service.signUp('testuser', 'password', [], null).then(() => {
+  try {
+    await service.signUp('testuser', 'password', [], null);
     assert.ok(false); // shouldn't get here.
-  }).catch((err) => {
+  } catch (err) {
     assert.equal(err, 'error');
-  });
+  }
 });

--- a/tests/unit/utils/mock-user-test.js
+++ b/tests/unit/utils/mock-user-test.js
@@ -5,21 +5,20 @@ import { get } from '@ember/object';
 
 module('Unit | Utility | mock user');
 
-test('updateAttributes adds new', function(assert) {
+test('updateAttributes adds new', async function(assert) {
   let user = MockUser.create({});
   let newAttr = new CognitoUserAttribute({
     Name: 'family_name',
     Value: 'Coltrane'
   });
 
-  return user.updateAttributes([newAttr]).then(() => {
-    assert.deepEqual(get(user, 'userAttributes'), [
-      { name: 'family_name', value: 'Coltrane' }
-    ]);
-  });
+  await user.updateAttributes([newAttr]);
+  assert.deepEqual(get(user, 'userAttributes'), [
+    { name: 'family_name', value: 'Coltrane' }
+  ]);
 });
 
-test('updateAttributes updates existing', function(assert) {
+test('updateAttributes updates existing', async function(assert) {
   let user = MockUser.create({
     userAttributes: [
       { name: 'given_name', value: 'John' },
@@ -32,11 +31,10 @@ test('updateAttributes updates existing', function(assert) {
     Value: 'New Trane'
   });
 
-  return user.updateAttributes([newAttr]).then(() => {
-    assert.deepEqual(get(user, 'userAttributes'), [
-      { name: 'given_name', value: 'John' },
-      { name: 'family_name', value: 'New Trane' }
-    ]);
-  });
+  await user.updateAttributes([newAttr]);
+  assert.deepEqual(get(user, 'userAttributes'), [
+    { name: 'given_name', value: 'John' },
+    { name: 'family_name', value: 'New Trane' }
+  ]);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,6 +2870,14 @@ ember-load-initializers@^1.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-maybe-import-regenerator-for-testing@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator-for-testing/-/ember-maybe-import-regenerator-for-testing-1.0.0.tgz#894b8089c5b3067c920b492c81233603852d5c2f"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    ember-cli-babel "^6.6.0"
+    regenerator-runtime "^0.9.5"
+
 ember-modules-codemod@^0.2.11:
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/ember-modules-codemod/-/ember-modules-codemod-0.2.11.tgz#e527867e264c87db3f7491fd3bdc60bbd6068890"
@@ -3136,6 +3144,12 @@ escodegen@^1.8.0:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.5.6"
+
+eslint-plugin-disable-features@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-disable-features/-/eslint-plugin-disable-features-0.1.3.tgz#f093418c860d7be41ed46519eedf3f70eb7e29f2"
+  dependencies:
+    requireindex "~1.1.0"
 
 eslint-plugin-ember@^5.0.0:
   version "5.0.3"
@@ -6597,6 +6611,10 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
@@ -6777,6 +6795,10 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 requires-port@1.x.x:
   version "1.0.0"


### PR DESCRIPTION
We're currently not switching to the new new test format, because that is still a bit too new and bleeding edge to be used as our documentation.

For whatever reason, `visit()` from `ember-native-dom-helpers` works, but `visit()` from `@ember/test-helpers` doesn't, at least in the non-nested modules versions.