### PR TITLE
[Fixes #68] New test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,29 @@ test('authenticated route', function(assert) {
 See [the dummy app](https://github.com/paulcwatts/ember-cognito/blob/master/tests/acceptance/index-test.js)
 for an example of this type of test.
 
+If your app is using `ember-cli-qunit` 4.2.0 or greater, consider migrating to the [modern testing syntax](https://dockyard.com/blog/2018/01/11/modern-ember-testing).
+In this case, helpers can be imported from the `ember-cognito` namespace, and can be used
+in any time of test (unit, integration, acceptance).
+
+
+```js
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { mockCognitoUser } from 'ember-cognito/test-support';
+
+module('Acceptance | authenticated route', function(hooks) {
+  test('authenticated route', async function(assert) {
+    await authenticateSession();
+    await mockCognitoUser({
+      username: 'testuser'
+      // userAttributes...
+    });
+    // No helper necessary to get the authenticator!
+    let authenticator = this.owner.lookup('authenticator:cognito');
+    
+  });
+});
+```
+
 ## Support
 
 ember-cognito is tested on Ember versions 2.12, 2.16 and 2.17+.

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,0 +1,18 @@
+import { getContext } from '@ember/test-helpers';
+import { set } from '@ember/object';
+import { MockUser } from './utils/ember-cognito';
+
+export function mockCognitoUser(userAttributes) {
+  const { owner } = getContext();
+  const cognito = owner.lookup('service:cognito');
+  set(cognito, 'user', MockUser.create(userAttributes));
+}
+
+export function unmockCognitoUser() {
+  const { owner } = getContext();
+  const cognito = owner.lookup('service:cognito');
+  set(cognito, 'user', undefined);
+}
+
+// Re-export MockUser so everything can be in this new namespace
+export { MockUser };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "^4.1.1",
+    "ember-cli-qunit": "^4.3.1",
     "ember-cli-release": "^1.0.0-beta.2",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",

--- a/tests/unit/utils/mock-helpers-test.js
+++ b/tests/unit/utils/mock-helpers-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { get } from '@ember/object';
+import { mockCognitoUser, unmockCognitoUser } from 'ember-cognito/test-support';
+
+module('Unit | Utility | flash errors', function(hooks) {
+  setupTest(hooks);
+
+  test('it works', async function(assert) {
+    await mockCognitoUser({
+      username: 'testuser',
+      userAttributes: [
+        { name: 'sub', value: 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh' },
+        { name: 'email', value: 'testuser@gmail.com' }
+      ]
+    });
+    let cognito = this.owner.lookup('service:cognito');
+    assert.deepEqual(get(cognito, 'user.userAttributes'), [
+      { name: 'sub', value: 'aaaabbbb-cccc-dddd-eeee-ffffgggghhhh' },
+      { name: 'email', value: 'testuser@gmail.com' }
+    ]);
+
+    await unmockCognitoUser();
+    assert.notOk(get(cognito, 'user'));
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@ember/test-helpers@^0.7.9":
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.13.tgz#89523a101b5bd731e9dcaf7d0c57155b6386a4e3"
+"@ember/test-helpers@^0.7.17":
+  version "0.7.17"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.17.tgz#17ff5f1d005d8b6331585e99013d66626a8d8068"
   dependencies:
     broccoli-funnel "^2.0.1"
     ember-cli-babel "^6.10.0"
@@ -2560,7 +2560,7 @@ electron-to-chromium@^1.3.30:
   dependencies:
     electron-releases "^2.1.0"
 
-ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9, ember-cli-babel@^6.10.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.0.0-beta.9, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz#79cb184bac3c05bfe181ddc306bac100ab1f9493"
   dependencies:
@@ -2734,12 +2734,12 @@ ember-cli-preprocess-registry@^3.1.0:
     process-relative-require "^1.0.0"
     silent-error "^1.0.0"
 
-ember-cli-qunit@^4.1.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-qunit/-/ember-cli-qunit-4.2.1.tgz#89580e6eb157ee98b9eefbd48fba9bb75ea64544"
+ember-cli-qunit@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-qunit/-/ember-cli-qunit-4.3.1.tgz#fcbf3585392299b27de26e57d0cf9f9049a76181"
   dependencies:
-    ember-cli-babel "^6.8.1"
-    ember-qunit "^3.2.2"
+    ember-cli-babel "^6.11.0"
+    ember-qunit "^3.3.1"
 
 ember-cli-release@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -2988,17 +2988,17 @@ ember-native-dom-helpers@^0.6.0:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
 
-ember-qunit@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.2.2.tgz#96c8818ecfa3894580a3dc805f7e7f1e82e07c4a"
+ember-qunit@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.3.1.tgz#8d68ef30cfd6f2acbf1d0f4e368439642e726903"
   dependencies:
-    "@ember/test-helpers" "^0.7.9"
+    "@ember/test-helpers" "^0.7.17"
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
     common-tags "^1.4.0"
     ember-cli-babel "^6.3.0"
     ember-cli-test-loader "^2.2.0"
-    qunit "^2.4.1"
+    qunit "^2.5.0"
 
 ember-resolver@^4.0.0:
   version "4.5.0"
@@ -6801,7 +6801,7 @@ quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quic
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit@^2.4.1:
+qunit@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.5.0.tgz#64cbe30a1193ef02edc5b278efcdf1d0bae96b22"
   dependencies:


### PR DESCRIPTION
The README depends on the latest version of ember-simple-auth. 

Note that we're not *yet* converting the test suite itself to the modern testing APIs. The test suite stands as examples of how one might want to write tests, and most people will most likely still be using the old test API. We do, however, need to include one *new* test to test the new functions!
