### PR TITLE
Fix invalidate() after refresh

### DIFF
--- a/addon/authenticators/cognito.js
+++ b/addon/authenticators/cognito.js
@@ -80,6 +80,8 @@ export default Base.extend({
         let newData = user.getStorageData();
         newData.access_token = session.getIdToken().getJwtToken();
         // newData.refreshed = new Date().toISOString();
+        newData.poolId = this.get('poolId');
+        newData.clientId = this.get('clientId');
         return newData;
       } else {
         return reject('session is invalid');

--- a/tests/unit/authenticators/cognito-test.js
+++ b/tests/unit/authenticators/cognito-test.js
@@ -294,8 +294,6 @@ module('Unit | Authenticator | cognito', function(hooks) {
       session,
       storageData: {
         access_token: 'oldtoken',
-        clientId: 'TEST',
-        poolId: 'us-east-1_TEST',
         'Cognito.StorageItem': 'test'
       }
     }));


### PR DESCRIPTION
After the refresh session timer refreshed the session, a call to `invalidate` would throw an exception because `poolId` and `clientId` weren't in the authentication data.

The storage data doesn't automatically contain the `poolId` and `clientId`, so we need to ensure it's still in the authentication data.