### PR TITLE
Fix invalidate case

### DIFF
--- a/addon/authenticators/cognito.js
+++ b/addon/authenticators/cognito.js
@@ -160,7 +160,9 @@ export default Base.extend({
 
   invalidate(data) {
     let user = this._getCurrentUser(data);
-    user.signOut();
+    if (user) {
+      user.signOut();
+    }
     set(this, 'cognito.user', undefined);
     return resolve(data);
   }


### PR DESCRIPTION
_getCurrentUser() can return null, but invalidate() wasn't checking against that.

I'm not certain of the circumstances in which this happens, but I believe it's when the Cognito current user information no longer exists or is invalid/expired.