### PR TITLE
Handle exceptions from cognito

### DIFF
--- a/addon/utils/cognito-user.js
+++ b/addon/utils/cognito-user.js
@@ -11,24 +11,33 @@ export default EmberObject.extend({
 
   _callback(method, ...args) {
     return new Promise((resolve, reject) => {
-      this.get('user')[method](...args, (err, result) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(result);
-        }
-      });
+      try {
+        this.get('user')[method](...args, (err, result) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(result);
+          }
+        });
+      } catch (error) {
+        reject(error);
+      }
     }, `cognito-user#${method}`);
   },
 
   // Support for methods that user { onSuccess, onFailure } callback hashes
   _callbackObj(method, ...args) {
     return new Promise((resolve, reject) => {
-      this.get('user')[method](...args, {
-        onSuccess: resolve,
-        onFailure: reject
-      });
-    }, `cognito-user#${method}`);
+        try {
+          this.get('user')[method](...args, {
+            onSuccess: resolve,
+            onFailure: reject
+          });
+        } catch (error) {
+          reject(error);
+        }
+      }, `cognito-user#${method}`);
+
   },
 
   changePassword(oldPassword, newPassword) {

--- a/addon/utils/cognito-user.js
+++ b/addon/utils/cognito-user.js
@@ -28,15 +28,15 @@ export default EmberObject.extend({
   // Support for methods that user { onSuccess, onFailure } callback hashes
   _callbackObj(method, ...args) {
     return new Promise((resolve, reject) => {
-        try {
-          this.get('user')[method](...args, {
-            onSuccess: resolve,
-            onFailure: reject
-          });
-        } catch (error) {
-          reject(error);
-        }
-      }, `cognito-user#${method}`);
+      try {
+        this.get('user')[method](...args, {
+          onSuccess: resolve,
+          onFailure: reject
+        });
+      } catch (error) {
+        reject(error);
+      }
+    }, `cognito-user#${method}`);
 
   },
 

--- a/tests/unit/utils/cognito-user-test.js
+++ b/tests/unit/utils/cognito-user-test.js
@@ -56,6 +56,19 @@ module('Unit | Utility | cognito user', function() {
       assert.equal(err, 'error');
     }
   });
+  sinonTest('getSession exception', async function(assert) {
+    let awsUser = getAwsUser();
+    this.stub(awsUser, 'getSession').callsFake(() => {
+      throw('error');
+    });
+    let user = CognitoUser.create({ user: awsUser });
+    try {
+      await user.getSession();
+      assert.ok(false);
+    } catch (err) {
+      assert.equal(err, 'error');
+    }
+  });
 
   sinonTest('changePassword', async function(assert) {
     assert.expect(2);
@@ -120,6 +133,21 @@ module('Unit | Utility | cognito user', function() {
     });
     let user = CognitoUser.create({ user: awsUser });
     await user.forgotPassword();
+  });
+  sinonTest('forgotPassword exception', async function(assert) {
+    assert.expect(1);
+
+    let awsUser = getAwsUser();
+    this.stub(awsUser, 'forgotPassword').callsFake(() => {
+      throw('some error');
+    });
+    let user = CognitoUser.create({ user: awsUser });
+
+    try {
+      await user.forgotPassword();
+    } catch (err) {
+      assert.equal(err, 'some error');
+    }
   });
 
   sinonTest('getAttributeVerificationCode', async function(assert) {

--- a/tests/unit/utils/cognito-user-test.js
+++ b/tests/unit/utils/cognito-user-test.js
@@ -45,9 +45,7 @@ module('Unit | Utility | cognito user', function() {
 
   sinonTest('getSession error', async function(assert) {
     let awsUser = getAwsUser();
-    this.stub(awsUser, 'getSession').callsFake((callback) => {
-      callback('error', null);
-    });
+    this.stub(awsUser, 'getSession').throws('error');
     let user = CognitoUser.create({ user: awsUser });
     try {
       await user.getSession();
@@ -138,9 +136,7 @@ module('Unit | Utility | cognito user', function() {
     assert.expect(1);
 
     let awsUser = getAwsUser();
-    this.stub(awsUser, 'forgotPassword').callsFake(() => {
-      throw('some error');
-    });
+    this.stub(awsUser, 'forgotPassword').throws('some error');
     let user = CognitoUser.create({ user: awsUser });
 
     try {


### PR DESCRIPTION
Cognito will throw exception in their code, specifically when a token is invalid, this change catches those exceptions and rejects the promise to allow for proper client side error handling of invalid sessions.