### PR TITLE
Add `deleteUser` method to `cognito-user` util

### DIFF
--- a/addon/utils/cognito-user.js
+++ b/addon/utils/cognito-user.js
@@ -56,6 +56,10 @@ export default EmberObject.extend({
     return this._callback('deleteAttributes', attributeList);
   },
 
+  deleteUser() {
+    return this._callback('deleteUser');
+  },
+
   forgotPassword() {
     return this._callbackObj('forgotPassword');
   },

--- a/tests/unit/utils/cognito-user-test.js
+++ b/tests/unit/utils/cognito-user-test.js
@@ -120,6 +120,16 @@ module('Unit | Utility | cognito user', function() {
     await user.deleteAttributes(['first_name', 'last_name']);
   });
 
+  sinonTest('deleteUser', async function(assert) {
+    let awsUser = getAwsUser();
+    this.stub(awsUser, 'deleteUser').callsFake((callback) => {
+      callback(null, 'SUCCESS');
+    });
+    let user = CognitoUser.create({ user: awsUser });
+    let text = await user.deleteUser();
+    assert.equal(text, 'SUCCESS');
+  });
+
   sinonTest('forgotPassword', async function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
This PR simply adds the missing `deleteUser` method to the `cognito-user` util.