### PR TITLE
Fix test in beta

### DIFF
--- a/tests/unit/authenticators/cognito-test.js
+++ b/tests/unit/authenticators/cognito-test.js
@@ -165,7 +165,7 @@ module('Unit | Authenticator | cognito', function(hooks) {
       'CognitoIdentityServiceProvider.TEST.LastAuthUser': 'testuser'
     };
     await service.restore(data);
-    assert.ok(get(service, 'cognito.task'), 'Refresh timer was scheduled.');
+    assert.ok(get(service, 'cognito.task') !== undefined, 'Refresh timer was scheduled.');
     let taskDuration = get(service, 'cognito._taskDuration');
     assert.ok(taskDuration > (1000 * 1000));
   });


### PR DESCRIPTION
The new backburner returns integers rather than strings for the task IDs.
In the old backburner, the task ID was "0" which is truthy.
In the new backburner, the task ID is 0 which is not.