### PR TITLE
[Fixes #131] Support hash attributes in the test user

### DIFF
--- a/tests/unit/utils/mock-user-test.js
+++ b/tests/unit/utils/mock-user-test.js
@@ -45,6 +45,33 @@ module('Unit | Utility | mock user', function() {
     ]);
   });
 
+  test('updateAttributes supports hash arguments', async function(assert) {
+    let user = MockUser.create({
+      userAttributes: [
+        { name: 'given_name', value: 'John' },
+        { name: 'family_name', value: 'Coltrane' }
+      ]
+    });
+    await user.updateAttributes({ family_name: "New Trane" });
+    assert.deepEqual(get(user, 'userAttributes'), [
+      { name: 'given_name', value: 'John' },
+      { name: 'family_name', value: 'New Trane' }
+    ]);
+  });
+
+  test('getUserAttributesHash', async function(assert) {
+    let user = MockUser.create({
+      userAttributes: [
+        { name: 'given_name', value: 'John' },
+        { name: 'family_name', value: 'Coltrane' }
+      ]
+    });
+    assert.deepEqual(await user.getUserAttributesHash(), {
+      given_name: 'John',
+      family_name: 'Coltrane'
+    })
+  });
+
   test('simple methods', async function(assert) {
     let user = MockUser.create();
     assert.deepEqual(await user.changePassword('old', 'new'), {});


### PR DESCRIPTION
This is needed to complement the additional functionality in the non-test class.