### PR TITLE
refactor: remove deprecated Ember.assign in favor of Object.assign

### DIFF
--- a/addon-test-support/utils/-mock-auth.js
+++ b/addon-test-support/utils/-mock-auth.js
@@ -6,14 +6,13 @@ import {
   CognitoRefreshToken,
   CognitoUserSession
 } from "amazon-cognito-identity-js";
-import { assign } from '@ember/polyfills';
 
 // Makes a JWT from a payload
 export function makeToken({ duration = 1000, header = 'header', extra = {} } = {}) {
   const now = Math.floor(new Date() / 1000);
   // To get a non-zero clock drift.
   const iat = now - 123;
-  const payload = assign({
+  const payload = Object.assign({
     iat,
     exp: iat + duration
   }, extra);

--- a/addon/services/cognito.js
+++ b/addon/services/cognito.js
@@ -1,5 +1,4 @@
 import Service, { inject as service } from '@ember/service';
-import { assign } from '@ember/polyfills';
 import CognitoUser from '../utils/cognito-user';
 import { normalizeAttributes } from "../utils/utils";
 import Auth from "@aws-amplify/auth";
@@ -27,7 +26,7 @@ export default Service.extend({
    */
   configure(awsconfig) {
     const { poolId, clientId } = this.getProperties('poolId', 'clientId');
-    const params =  assign({
+    const params =  Object.assign({
       userPoolId: poolId,
       userPoolWebClientId: clientId,
     }, awsconfig);

--- a/app/services/cognito.js
+++ b/app/services/cognito.js
@@ -1,8 +1,7 @@
 import CognitoService from 'ember-cognito/services/cognito';
 import ENV from '../config/environment';
-import { assign } from '@ember/polyfills';
 
-const cognitoEnv = assign({
+const cognitoEnv = Object.assign({
   autoRefreshSession: false
 }, ENV.cognito);
 


### PR DESCRIPTION
Hi, thanks for your addon ;)

I'm doing some upgrades and I see ember-cognito throwing a deprecation warning for Ember.assign.
This swaps Ember.assign with Object.assign which was used anyway in most cases, additionally e-cognito removed support for 2.x ember versions, so we should be ok with the change.